### PR TITLE
QA-9268 : correct captcha behavior

### DIFF
--- a/src/main/resources/jnt_captcha/html/captcha.jsp
+++ b/src/main/resources/jnt_captcha/html/captcha.jsp
@@ -24,6 +24,7 @@
         <input ${disabled} type="text" ${required} class="${required}" id="inputCaptcha" name="jcrCaptcha"/>
         <c:if test="${not empty sessionScope.formError}">
             <label class="error">${sessionScope.formError}</label>
+            <c:set var="formError" value="" scope="session"/>
         </c:if>
     </p>
 </div>

--- a/src/main/resources/jnt_form/html/form.jsp
+++ b/src/main/resources/jnt_form/html/form.jsp
@@ -95,6 +95,7 @@
                 <input type="hidden" name="jcrRedirectTo" value="<c:url value='${url.base}${renderContext.mainResource.node.path}'/>"/>
                     <%-- Define the output format for the newly created node by default html or by jcrRedirectTo--%>
                 <input type="hidden" name="jcrNewNodeOutputFormat" value="html"/>
+                <input type="hidden" name="jcrResourceID" value="${currentNode.identifier}"/>
                 <c:if test="${not empty chainActive}">
                     <input type="hidden" name="chainOfAction" value="${chainActive}"/>
                 </c:if>


### PR DESCRIPTION
1. The variable "formError" (session scope) is cleared once it's displayed, this way it will prevent the error to be always displayed
2. The hidden input "jcrResourceId" is added to the form so it will help bypass the cache when a "formError" is present and this way, the fields of the form won't be initialized : consequently, the user won't have to fill again the form.
